### PR TITLE
added gitlab CI file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,9 +16,9 @@ copy_nanoaod:
 tests_cpu:
   stage: tests_cpu
   script:
-    - HEPACCELERATE_CUDA=0 singularity --nv exec ${singularity_image} python3 setup.py test
+    - HEPACCELERATE_CUDA=0 singularity exec --nv ${singularity_image} python3 setup.py test
 
 tests_cuda:
   stage: tests_gpu
   script:
-    - HEPACCELERATE_CUDA=1 singularity --nv exec ${singularity_image} python3 setup.py test
+    - HEPACCELERATE_CUDA=1 singularity exec --nv ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,17 +1,24 @@
 stages:
+  - inputs
   - tests_cpu
   - tests_gpu
 
 #image used to run code
 variables:
   singularity_image: /storage/user/jpata/cupy2.simg
+  input_data_cache: /storage/user/jpata/ci_cache
+
+copy_nanoaod:
+  stage: inputs
+  script:
+    - cp ${input_data_cache}/nanoaod_test.root ./
 
 tests_cpu:
   stage: tests_cpu
   script:
-    - HEPACCELERATE_CUDA=0 singularity exec ${singularity_image} python3 setup.py test
+    - HEPACCELERATE_CUDA=0 singularity --nv exec ${singularity_image} python3 setup.py test
 
 tests_cuda:
   stage: tests_gpu
   script:
-    - HEPACCELERATE_CUDA=1 singularity exec ${singularity_image} python3 setup.py test
+    - HEPACCELERATE_CUDA=1 singularity --nv exec ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,9 +9,9 @@ variables:
 tests_cpu:
   stage: tests_cpu
   script:
-    - HEPACCELERATE_CUDA=0 singularity exec ${singularity_image} python3 setup.py tests
+    - HEPACCELERATE_CUDA=0 singularity exec ${singularity_image} python3 setup.py test
 
 tests_cuda:
   stage: tests_gpu
   script:
-    - HEPACCELERATE_CUDA=1 singularity exec ${singularity_image} python3 setup.py tests
+    - HEPACCELERATE_CUDA=1 singularity exec ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,4 +19,4 @@ tests_cuda:
   allow_failure: true
   script:
     - cp ${input_data_cache}/nanoaod_test.root ./data/nanoaod_test.root
-    - HEPACCELERATE_CUDA=1 singularity exec --nv ${singularity_image} python3 setup.py test
+    - HEPACCELERATE_CUDA=1 CUDA_VISIBLE_DEVICES=`./tests/free_gpu.sh` singularity exec --nv ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,11 +10,11 @@ variables:
 tests_cpu:
   stage: tests_cpu
   script:
-    - cp ${input_data_cache}/nanoaod_test.root ./
+    - cp ${input_data_cache}/nanoaod_test.root ./data/nanoaod_test.root
     - HEPACCELERATE_CUDA=0 singularity exec --nv ${singularity_image} python3 setup.py test
 
 tests_cuda:
   stage: tests_gpu
   script:
-    - cp ${input_data_cache}/nanoaod_test.root ./
+    - cp ${input_data_cache}/nanoaod_test.root ./data/nanoaod_test.root
     - HEPACCELERATE_CUDA=1 singularity exec --nv ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,10 @@ tests_cpu:
     - cp ${input_data_cache}/nanoaod_test.root ./data/nanoaod_test.root
     - HEPACCELERATE_CUDA=0 singularity exec --nv ${singularity_image} python3 setup.py test
 
+#CUDA test is allowed to fail in case the GPUs are actively in use
 tests_cuda:
   stage: tests_gpu
+  allow_failure: true
   script:
     - cp ${input_data_cache}/nanoaod_test.root ./data/nanoaod_test.root
     - HEPACCELERATE_CUDA=1 singularity exec --nv ${singularity_image} python3 setup.py test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+stages:
+  - tests_cpu
+  - tests_gpu
+
+#image used to run code
+variables:
+  singularity_image: /storage/user/jpata/cupy2.simg
+
+tests_cpu:
+  stage: tests_cpu
+  script:
+    - HEPACCELERATE_CUDA=0 singularity exec ${singularity_image} python3 setup.py tests
+
+tests_cuda:
+  stage: tests_gpu
+  script:
+    - HEPACCELERATE_CUDA=1 singularity exec ${singularity_image} python3 setup.py tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - inputs
   - tests_cpu
   - tests_gpu
 
@@ -8,17 +7,14 @@ variables:
   singularity_image: /storage/user/jpata/cupy2.simg
   input_data_cache: /storage/user/jpata/ci_cache
 
-copy_nanoaod:
-  stage: inputs
-  script:
-    - cp ${input_data_cache}/nanoaod_test.root ./
-
 tests_cpu:
   stage: tests_cpu
   script:
+    - cp ${input_data_cache}/nanoaod_test.root ./
     - HEPACCELERATE_CUDA=0 singularity exec --nv ${singularity_image} python3 setup.py test
 
 tests_cuda:
   stage: tests_gpu
   script:
+    - cp ${input_data_cache}/nanoaod_test.root ./
     - HEPACCELERATE_CUDA=1 singularity exec --nv ${singularity_image} python3 setup.py test

--- a/tests/free_gpu.sh
+++ b/tests/free_gpu.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+nvidia-smi pmon -c 1 -s u 2 &> /dev/null | grep "-" | awk '{print $1}' | head -n1


### PR DESCRIPTION
I set up simple CI integration with gitlab.cern.ch. What was needed:
- on gitlab.cern.ch, set up a mirrored repository [jpata/hepaccelerate](https://gitlab.cern.ch/jpata/hepaccelerate) that has pull mirroring to the base github repo
- add a gitlab custom runner to it that is running on mawhrin-skel-sm.hep.caltech.edu
- add a github webhook on this repo with a gitlab private token that triggers a pull on gitlab on every push on github (hope that sentence makes sense)

Currently, I'm discussing with other Caltech people on how to ensure we have always a GPU free for testing.

cc @chreissel if you want to take a look 🙂