### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1.2.0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .
+        python -m pip list
+    - name: Test examples
+      run: |
+        python hepaccelerate/kernels.py
+        python examples/ex1.py
+        python examples/ex2.py
+    - name: Test
+      run: |
+        curl -k https://jpata.web.cern.ch/jpata/opendata_files/DY2JetsToLL-merged/1.root -o data/nanoaod_test.root
+        python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![GitHub Actions Status: CI](https://github.com/hepaccelerate/hepaccelerate/workflows/CI/CD/badge.svg)](https://github.com/hepaccelerate/hepaccelerate/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
 [![Build Status](https://travis-ci.com/hepaccelerate/hepaccelerate.svg?branch=master)](https://travis-ci.com/hepaccelerate/hepaccelerate)
 [![pipeline status](https://gitlab.cern.ch/jpata/hepaccelerate/badges/master/pipeline.svg)](https://gitlab.cern.ch/jpata/hepaccelerate/commits/master)
 [![DOI](https://zenodo.org/badge/191644111.svg)](https://zenodo.org/badge/latestdoi/191644111)


### PR DESCRIPTION
Add CI using GitHub Actions to run tests on Python 3.6, 3.7, 3.8 across Linux and MacOS. The CI will run on `push` and `pull_request` events, and additionally as a nightly CRON job (excellent for detecting upcoming issues due to dependency changes).

This PR is the first in a series that will _eventually_ get around to addressing our discussion in Issue #8 (thought it might take some time :wink:).